### PR TITLE
Be more pythonic

### DIFF
--- a/gqlmod/providers.py
+++ b/gqlmod/providers.py
@@ -91,8 +91,10 @@ def _mock_provider(name, instance):
 
 def _process_result(res):
     if isinstance(res, dict):
-        data = res.get('data', None)
-        errors = res.get('errors', [])
+        # This will convert the response into the rich error type
+        res = graphql.build_response(res)
+        data = res.data
+        errors = res.data
     elif isinstance(res, graphql.ExecutionResult):
         data = res.data
         errors = res.errors
@@ -102,7 +104,7 @@ def _process_result(res):
         )
 
     if errors:
-        # Errors are present. Discard the data and raise that.
+        # Errors are present. Discard the data and raise those.
         # TODO: Map the error locations back to the source file's location
         assert len(errors) > 0
         if len(errors) == 1:
@@ -135,7 +137,7 @@ async def exec_query_async(provider, query, **variables):
     """
     prov = get_provider(provider)
     result = await prov.query_async(query, variables)
-    return (result)
+    return _process_result(result)
 
 
 @functools.lru_cache()

--- a/testmod/__main__.py
+++ b/testmod/__main__.py
@@ -12,11 +12,10 @@ assert all(callable(getattr(testmod.queries, name)) for name in qnames)
 
 print("")
 
-result = testmod.queries.HeroNameAndFriends()
-assert not result.errors
-pprint(result.data)
+data = testmod.queries.HeroNameAndFriends()
+pprint(data)
 
-assert result.data == {
+assert data == {
     'hero': {'friends': [{'name': 'Luke Skywalker'},
                          {'name': 'Han Solo'},
                          {'name': 'Leia Organa'}],

--- a/tests/test_gql.py
+++ b/tests/test_gql.py
@@ -13,9 +13,8 @@ def test_names():
 
 def test_data_sync():
     import testmod.queries_sync
-    result = testmod.queries_sync.HeroNameAndFriends()
-    assert not result.errors
-    assert result.data == {
+    data = testmod.queries_sync.HeroNameAndFriends()
+    assert data == {
         'hero': {'friends': [{'name': 'Luke Skywalker'},
                              {'name': 'Han Solo'},
                              {'name': 'Leia Organa'}],
@@ -25,9 +24,8 @@ def test_data_sync():
 @pytest.mark.asyncio
 async def test_data_async():
     import testmod.queries_async
-    result = await testmod.queries_async.HeroNameAndFriends()
-    assert not result.errors
-    assert result.data == {
+    data = await testmod.queries_async.HeroNameAndFriends()
+    assert data == {
         'hero': {'friends': [{'name': 'Luke Skywalker'},
                              {'name': 'Han Solo'},
                              {'name': 'Leia Organa'}],


### PR DESCRIPTION
Return the data directly instead of a data/error bag.

This will make calling queries a lot less weird (ie, no `assert not res.errors`)

Fixes #13 